### PR TITLE
Updating dependency name to match pub repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Add this to your pubspec.yaml dependencies:
 
 ```yaml
 dependencies:
-  arc_progress_bar: ^1.0.4
+  arc_progress_bar_new: ^1.0.4
 ```
 
 ## How to use


### PR DESCRIPTION
The current readme is telling you to use the dependency by its old name (arc_progress_bar), but looking in pub.dev package is arc_progress_bar_new: https://pub.dev/packages/arc_progress_bar_new

So trying it with the current readme requires you to use the 0.0.1 version here: https://pub.dev/packages/arc_progress_bar